### PR TITLE
Turn on Meson release build optimizations.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('vivtc', 'c', 'cpp',
   version : '1',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3', 'buildtype=release', 'b_ndebug=if-release'])
 
 add_project_arguments('-ffast-math', language : 'c')
 


### PR DESCRIPTION
Just like my other PR, nice performance boost with using the -O3 defaults of meson in release mode:

Benchmark script
```
import vapoursynth as vs
core = vs.core

clip = core.ffms2.Source('./source.mkv')

clip = clip.vivtc.VFM(1)

clip.set_output()

```

Results:
* Raw clip: 736fps
* Old code: 280 fps
* New code: 430 fps

I only benched with VFM as I have a progressive input, but I'm sure VDecimate has some gains as well. I can rerun benchmarks to include it if desired.